### PR TITLE
hotfix to only remove the <p> if it contains plain text without any child elements (<a>, <img>m etc.)

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -599,8 +599,8 @@ $(document).ready(function () {
         let elements = div.find('li, th, td, dt, dd');
         elements.each(function () {
             let paragraphs = $(this).find('p');
-            if (paragraphs.length === 1) {
-                let content = paragraphs[0].innerHTML;
+            if (paragraphs.length === 1 && paragraphs.children().length === 0) {
+                let content = paragraphs.innerHTML;
                 $(this).html(content);
             }
         });

--- a/scripts.js
+++ b/scripts.js
@@ -603,6 +603,10 @@ $(document).ready(function () {
                 let content = paragraphs.innerHTML;
                 $(this).html(content);
             }
+            if (paragraphs.length === 1) {
+                let content = paragraphs[0].innerHTML;
+                $(this).html(content);
+            }
         });
 
         // beautify the HTML code using js-beautify custom options


### PR DESCRIPTION
Code snippet for testing:
<ol class="media-list">
    <li class="media"><a class="pull-right" href="https://www.canada.ca/en/shared-services/campaigns/stories/closing-door-on-legacy-problems.html"><img class="media-object" src="..." alt="" /></a>
        <div class="media-body">
            <h3 class="media-heading">Closing the door on legacy problems</h3>
            <p>Read how SSC experts moved NRCan’s workload to environmentally sustainable enterprise data centres, resulting in improved availability and cost savings.</p>
        </div>
    </li>
</ol>