### PR TITLE
H1 to url

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,11 +110,17 @@
                         <ul>
                             <li>Removes UTM codes from links that accidentally contains them</li>
                         </ul>
+
+                        <h2 class="h3">Canada.ca h1 to URL <span class="fs-6">(only for Canada.ca pages)</span></h2>
+
+                        <ul>
+                            <li>Extract title from the text area input: prefer first <code>&lt;h1&gt;</code>, then <code>&lt;title&gt;</code>, then first text line</li>
+                            <li><a href="https://design.canada.ca/specifications/mandatory-elements/domains-urls.html#du3a">Canada.ca URL rules</a></li>
                     </div>
                 </div>
             </div>
         </div>
-        
+
         <div class="clearfix">&nbsp;</div>
 
         <textarea id="textareaID" placeholder="Paste your HTML here"></textarea>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
             <li class="action-item"><button id="btn-details-summary-fra">H2 to details/summary FR</button></li>
             <li class="action-item"><button id="btn-remove-utm-codes">Remove UTM codes</button></li>
             <li class="action-item"><button id="btn-canada-links">Canada.ca links (only for Canada.ca pages)</button></li>
+            <li class="action-item"><button id="btn-canada-urls">Canada.ca h1 to URL (only for Canada.ca pages)</button></li>
             <li class="action-item"><button id="btn-copy-code">Copy code</button></li>
         </ul>
 

--- a/scripts.js
+++ b/scripts.js
@@ -898,7 +898,7 @@ $(document).ready(function () {
 
     // function to detect French
     function detectFrench(text) {
-        return /[éèêàùçôîûœâÄÉÈÊÔÛÎ]/.test(text) || /\b(le|la|les|un|une|de|du|des|pour|avec|sur|dans|et|est)\b/i.test(text);
+        return /[éèêàùçôîûœâÄÉÈÊÔÛÎ]/.test(text) || /\b(le|la|les|un|une|en|de|du|des|pour|avec|sur|dans|et|est)\b/i.test(text);
     }
 
     // Convert title to a Canada-style
@@ -926,10 +926,10 @@ $(document).ready(function () {
 
         // Stop-words (small lists). French includes 'a' so that 'à' -> 'a' gets removed
         const stopEn = ['to','the','a','an','by','for','of','how','on','in','and','or','with','is','are','what'];
-        const stopFr = ['de','du','des','la','le','les','un','une','par','pour','sur','dans','et','ou','avec','est','sont','comment','a'];
+        const stopFr = ['de','du','des','la','le','les','un','une','en','par','pour','sur','dans','et','ou','avec','est','sont','comment','a'];
         const stop = isFrench ? stopFr : stopEn;
 
-        // Remove stop words but keep numbers and acronyms; ensure we don't remove everything
+        // Remove stop words but keep numbers and acronyms (ensure we don't remove everything)
         if (tokens.length > 1) {
             tokens = tokens.filter(t => !stop.includes(t));
             if (tokens.length === 0) return null;


### PR DESCRIPTION
<p>Extract title from the text area input: prefer first &lt;h1&gt;, then &lt;title&gt;, then first text line.</p>

<p>Rational:</p>

<ul>
    <li>use plain language keywords</li>
    <li>separate keywords within the same path segments by hyphens</li>
    <li>avoid superfluous words such as “to”, “the”, “a”, “an”, “by”, “for” (for example, use “/apply-student-loan” instead of “/how-to-apply-for-a-canadian-student-loan”)</li>
    <li>use lowercase</li>
    <li>use unilingual keywords, in the language of the page</li>
    <li>use only US-ASCII (7-bit version of ASCII) characters (for example, use “meteo” instead of “météo”)</li>
    <li>avoid duplicate keywords and apostrophes</li>
    <li>avoid acronyms and abbreviations, unless they are better understood than the full version or perform better on search engines</li>
</ul>